### PR TITLE
Rebrand

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -42,7 +42,8 @@ pipeline {
 
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A podman image for nexus')
-        NAME = getRepoName()
+//        NAME = getRepoName()
+        NAME = 'metal-observability'
         IS_STABLE = "${isStable}"
         PRIMARY_NODE = "${env.NODE_NAME}"
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | sed 's/^v//'").trim()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# pit-observability
+# metal-observability
+
+Provides Grafana and Prometheus monitoring services for bare-metal through `podman` and `systemd`. 

--- a/metal-observability.spec
+++ b/metal-observability.spec
@@ -52,6 +52,7 @@ BuildRequires: skopeo
 BuildRequires: pkgconfig(systemd)
 Requires: podman
 Requires: podman-cni-config
+provides: pit-observability
 %{?systemd_ordering}
 
 %define imagedir %{_sharedstatedir}/cray/container-images/%{name}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Docs Pull Request

<!--- words; describe what this change is and what it is for. -->
We may want to use this in places outside of the pre-install toolkit. This rebranding removes the PIT concession.

The built RPM still provides `pit-observability` by name, the package can now be referenced by both commands:

```bash
zypper in pit-observability
zypper in metal-observability
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
